### PR TITLE
remove the @types/core-js dep and add es2015 lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "zone.js": "^0.6.23"
   },
   "devDependencies": {
-    "@types/core-js": "^0.9.34",
     "typescript": "^2.0.10"
   },
   "typings": "index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "lib": [
+            "es2015",
+            "dom"
+        ]
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
I have tried this out a couple of projects now and this seems to take care of the es2015 interfaces that are needed and does not create any duplicate declarations.