### PR TITLE
Upgrade esri loader service

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/tomwayson/angular2-esri-loader#readme",
   "dependencies": {
     "@angular/core": "^2.1.0",
-    "esri-loader": "^0.1.2",
+    "esri-loader": "^1.0.0",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.23"
   },


### PR DESCRIPTION
This is to bring in the change in `esri-loader` that allows for applications using this library to be used inside of Electron.  It also probably satisfies #5.