### PR TITLE
It's just angular-esri-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,47 @@ export class EsriMapComponent implements OnInit {
 }
 ```
 
+### In an Angular 2 Application
+
+Example of using the loader service in a component to lazy load the ArcGIS API and create a map
+
+```ts
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+
+import { EsriLoaderService } from 'angular-esri-loader';
+
+@Component({
+  selector: 'app-esri-map',
+  templateUrl: './esri-map.component.html',
+  styleUrls: ['./esri-map.component.css']
+})
+export class EsriMapComponent implements OnInit {
+  @ViewChild('map') mapEl: ElementRef;
+  
+  map: any;
+
+  constructor(private esriLoader: EsriLoaderService) { }
+
+  ngOnInit() {
+    // only load the ArcGIS API for JavaScript when this component is loaded
+    return this.esriLoader.load({
+      // use a specific version of the API instead of the latest
+      url: '//js.arcgis.com/3.18/'
+    }).then(() => {
+      // load the map class needed to create a new map
+      this.esriLoader.loadModules(['esri/map']).then(([Map]) => {
+        // create the map at the DOM element in this component
+        this.map = new Map(this.mapEl.nativeElement, {
+          center: [-118, 34.5],
+          zoom: 8,
+          basemap: 'dark-gray'
+        });
+      });
+    });
+  }
+}
+```
+
 ### In an Angular CLI Application
 
 To use this library in an [Angular CLI](https://github.com/angular/angular-cli) application, the best place to start is to follow the instructions in [this gist](https://gist.github.com/tomwayson/e6260adfd56c2529313936528b8adacd).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# angular2-esri-loader
+# angular-esri-loader
 An [Angular](https://angular.io/) library to help you load [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) modules. 
 
 Exposes a service that wraps the functions from the [esri-loader](https://github.com/tomwayson/esri-loader) library in new functions that return promises.
@@ -6,9 +6,19 @@ Exposes a service that wraps the functions from the [esri-loader](https://github
 To understand why this is needed, and the benefits of using esri-loader over other techniques, see the [esri-loader README](https://github.com/tomwayson/esri-loader#why-is-this-needed).
 
 ## Install
+For Angular 4 and above:
+
+```bash
+npm install angular-esri-loader
+```
+
+For Angular 2:
+
 ```bash
 npm install angular2-esri-loader esri-loader
 ```
+
+**NOTE**: for Angular.js use [angular-esri-map](https://github.com/Esri/angular-esri-map).
 
 ## Usage
 Example of using the loader service in a component to lazy load the ArcGIS API and create a map
@@ -16,7 +26,7 @@ Example of using the loader service in a component to lazy load the ArcGIS API a
 ```ts
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 
-import { EsriLoaderService } from 'angular2-esri-loader';
+import { EsriLoaderService } from 'angular-esri-loader';
 
 @Component({
   selector: 'app-esri-map',

--- a/README.md
+++ b/README.md
@@ -18,14 +18,40 @@ For Angular 2:
 npm install angular2-esri-loader esri-loader
 ```
 
-**NOTE**: for Angular.js use [angular-esri-map](https://github.com/Esri/angular-esri-map).
+**NOTE**: for AngularJS use [angular-esri-map](https://github.com/Esri/angular-esri-map).
 
 ## Usage
-Example of using the loader service in a component to lazy load the ArcGIS API and create a map
+
+Below is an example of using the loader service in a component to lazy load the ArcGIS API and create a map.
+
+First you need to import the `EsriLoaderModule` into your application:
+
+```ts
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { EsriLoaderModule } from 'angular-esri-loader';
+
+import { AppComponent } from './app.component';
+import { EsriMapComponent } from './esri-map.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    EsriMapComponent
+  ],
+  imports: [
+    BrowserModule,
+    EsriLoaderModule,
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+```
+
+Then you can use the `EsriLoaderService` in a component to load a map:
 
 ```ts
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
-
 import { EsriLoaderService } from 'angular-esri-loader';
 
 @Component({

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ export class EsriMapComponent implements OnInit {
 }
 ```
 
+### In an Angular CLI Application
+
+To use this library in an [Angular CLI](https://github.com/angular/angular-cli) application, the best place to start is to follow the instructions in [this gist](https://gist.github.com/tomwayson/e6260adfd56c2529313936528b8adacd).
+
+For an example of how to use this service to lazy load the ArcGIS API and resolve modules in a route, see 
+[esri-angular-cli-example's esri-map-resolve.service.ts](https://github.com/tomwayson/esri-angular-cli-example/blob/ab4540912904cf78ccfd904fb3bfa4c69b4aa1da/src/app/esri-map/esri-map-resolve.service.ts).
+
+### In an angular2-webpack-starter Application
+
+See [this gist](https://gist.github.com/jwasilgeo/00855ee002aca822e33abd8a7a031f56) for instructions on how to use this library in an [AngularClass/angular2-webpack-starter](https://github.com/AngularClass/angular2-webpack-starter) application.
+
 ### In an Angular 2 Application
 
 Example of using the loader service in a component to lazy load the ArcGIS API and create a map
@@ -126,17 +137,6 @@ export class EsriMapComponent implements OnInit {
   }
 }
 ```
-
-### In an Angular CLI Application
-
-To use this library in an [Angular CLI](https://github.com/angular/angular-cli) application, the best place to start is to follow the instructions in [this gist](https://gist.github.com/tomwayson/e6260adfd56c2529313936528b8adacd).
-
-For an example of how to use this service to lazy load the ArcGIS API and resolve modules in a route, see 
-[esri-angular-cli-example's esri-map-resolve.service.ts](https://github.com/tomwayson/esri-angular-cli-example/blob/ab4540912904cf78ccfd904fb3bfa4c69b4aa1da/src/app/esri-map/esri-map-resolve.service.ts).
-
-### In an angular2-webpack-starter Application
-
-See [this gist](https://gist.github.com/jwasilgeo/00855ee002aca822e33abd8a7a031f56) for instructions on how to use this library in an [AngularClass/angular2-webpack-starter](https://github.com/AngularClass/angular2-webpack-starter) application.
 
 ## ArcGIS Types
 This service doesn't make any assumptions about which version of the ArcGIS API you are using, so you will have to manually install the appropriate types.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular2-esri-loader",
+  "name": "angular-esri-loader",
   "version": "1.0.0",
   "description": "An Angular (2+) service to help you load ArcGIS API for JavaScript Modules",
   "scripts": {
@@ -7,14 +7,14 @@
     "clean": "rimraf build dist",
     "copy": "copyfiles -u 1 \"build/**/*{.d.ts,.js.map,.metadata.json}\" dist && copyfiles -f src/package.json README.md dist",
     "ngc": "ngc -p tsconfig.json",
-    "rollup": "rollup build/angular2-esri-loader.js -o dist/angular2-esri-loader.js",
+    "rollup": "rollup build/angular-esri-loader.js -o dist/angular-esri-loader.js",
     "prepublish": "npm run build",
     "preversion": "npm run test && git add README.md CHANGELOG.md",
     "test": "ngc"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tomwayson/angular2-esri-loader.git"
+    "url": "git+https://github.com/tomwayson/angular-esri-loader.git"
   },
   "keywords": [
     "Angular",
@@ -24,9 +24,9 @@
   "author": "Tom Wayson <tom@tomwayson.com> (https://tomwayson.com)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tomwayson/angular2-esri-loader/issues"
+    "url": "https://github.com/tomwayson/angular-esri-loader/issues"
   },
-  "homepage": "https://github.com/tomwayson/angular2-esri-loader#readme",
+  "homepage": "https://github.com/tomwayson/angular-esri-loader#readme",
   "devDependencies": {
     "@angular/compiler": "^4.1.1",
     "@angular/compiler-cli": "^4.1.1",

--- a/src/package.json
+++ b/src/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "angular2-esri-loader",
+  "name": "angular-esri-loader",
   "version": "0.1.11",
   "description": "An Angular (2+) service to help you load ArcGIS API for JavaScript modules",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tomwayson/angular2-esri-loader.git"
+    "url": "git+https://github.com/tomwayson/angular-esri-loader.git"
   },
   "keywords": [
     "Angular",
@@ -14,9 +14,9 @@
   "author": "Tom Wayson <tom@tomwayson.com> (https://tomwayson.com)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tomwayson/angular2-esri-loader/issues"
+    "url": "https://github.com/tomwayson/angular-esri-loader/issues"
   },
-  "homepage": "https://github.com/tomwayson/angular2-esri-loader#readme",
+  "homepage": "https://github.com/tomwayson/angular-esri-loader#readme",
   "dependencies": {
     "esri-loader": "^1.0.0"
   },
@@ -25,6 +25,6 @@
     "rxjs": "^5.3.0",
     "zone.js": "^0.8.5"
   },
-  "module": "angular2-esri-loader.js",
-  "typings": "angular2-esri-loader.d.ts"
+  "module": "angular-esri-loader.js",
+  "typings": "angular-esri-loader.d.ts"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
         "annotateForClosureCompiler": true,
         "strictMetadataEmit": true,
         "skipTemplateCodegen": true,
-        "flatModuleOutFile": "angular2-esri-loader.js",
-        "flatModuleId": "angular2-esri-loader"
+        "flatModuleOutFile": "angular-esri-loader.js",
+        "flatModuleId": "angular-esri-loader"
     }
 }


### PR DESCRIPTION
These are the code changes required to resolve #15 

I've tested locally via `npm link` and this seems to work.

In addition to these changes, after merging we'll need to:
- [ ] ~~rename v1.0.0 tag to angular2-esri-loader-v1.0.0~~
- [x] rename repo to angular-esri-loader
- [x] publish angular-esri-loader@1.1.0
- [ ] update the gists:
  - [angular-cli](https://gist.github.com/tomwayson/e6260adfd56c2529313936528b8adacd)
  - [angular class starter](https://gist.github.com/jwasilgeo/00855ee002aca822e33abd8a7a031f56)
- [x] update links from:
 - [esri-loader](https://github.com/tomwayson/esri-loader/search?q=angular2-esri-loader&type=Code&utf8=%E2%9C%93)
 - [jsapi-resources](https://github.com/Esri/jsapi-resources/search?utf8=%E2%9C%93&q=angular2-esri-loader&type=)

If this looks good, I can take care of most of that, except as follows:

@TheKeithStewart 

One thing I noticed, the gists and [usage](https://github.com/tomwayson/angular2-esri-loader#usage) instructions all use the service directly (instead of via the NgModule) Do you think they should be changed? If so, would you mind adding a commit to this PR that updates the usage accordingly and I'll put that in the gists.

Also, once you update angular2-esri4-components to use angular-esri-loader, we'll need to 
update [esri-angular-cli-example](https://github.com/tomwayson/esri-angular-cli-example/search?utf8=%E2%9C%93&q=angular2-esri-loader&type=)

@jwasilgeo after I update my gist, would you mind updating yours?
