### PR TITLE
update for esri-loader 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-esri-loader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An Angular service to help you load ArcGIS API for JavaScript Modules",
   "scripts": {
     "build": "npm run clean && npm run ngc && npm run rollup && npm run copy",

--- a/src/services/esri-loader.service.ts
+++ b/src/services/esri-loader.service.ts
@@ -12,7 +12,7 @@ export class EsriLoaderService {
   }
 
   //use to save options passed to load()
-  private loadScriptOptions: ILoadScriptOptions;
+  private loadScriptOptions: ILoadScriptOptions = {};
 
   // lazy load the ArcGIS API for JavaScript
   // only need to use load() is specifying something other than the default options

--- a/src/services/esri-loader.service.ts
+++ b/src/services/esri-loader.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@angular/core';
-import { loadModules, loadScript, ILoadScriptOptions } from 'esri-loader';
+import { isLoaded, loadModules, loadScript, ILoadScriptOptions } from 'esri-loader';
 
 @Injectable()
 export class EsriLoaderService {
 
   constructor() { }
+
+  //no longer used here, but may still be useful to other people
+  isLoaded() {
+    return isLoaded();
+  }
 
   //use to save options passed to load()
   private loadScriptOptions: ILoadScriptOptions;

--- a/src/services/esri-loader.service.ts
+++ b/src/services/esri-loader.service.ts
@@ -1,44 +1,28 @@
 import { Injectable } from '@angular/core';
-import { isLoaded, bootstrap, dojoRequire } from 'esri-loader';
+import { loadModules, loadScript, ILoadScriptOptions } from 'esri-loader';
 
 @Injectable()
 export class EsriLoaderService {
 
   constructor() { }
 
-  isLoaded() {
-    return isLoaded();
-  }
+  //use to save options passed to load()
+  private loadScriptOptions: ILoadScriptOptions;
 
   // lazy load the ArcGIS API for JavaScript
-  load(options?: Object): Promise<Function> {
-    return new Promise((resolve: Function, reject: Function) => {
-      // don't try to load a second time
-      if (isLoaded()) {
-        resolve(dojoRequire);
-      }
-      // wrap bootstrap in a promise
-      bootstrap((err: Error) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(dojoRequire);
-        }
-      }, options);
-    });
+  // only need to use load() is specifying something other than the default options
+  load(options?: ILoadScriptOptions): Promise<HTMLScriptElement> {
+    this.loadScriptOptions = options ? options : {};
+    return loadScript(options);
   }
 
-  // wrap Dojo require in a promise
+  // will use defaults if load() has not been called
   loadModules(moduleNames: string[]): Promise<any[]> {
-    return new Promise((resolve: Function) => {
-      dojoRequire(moduleNames, (...modules: any[]) => {
-        resolve(modules);
-      });
-    });
+    return loadModules(moduleNames, this.loadScriptOptions);
   }
 
   // convenience function to allow calling Dojo require w/ callback
-  require(moduleNames: string[], callback: Function) {
-    return dojoRequire(moduleNames, callback);
+  require(moduleNames: string[], callback: any) {
+    return loadModules(moduleNames, this.loadScriptOptions).then(callback);
   }
 }


### PR DESCRIPTION
checked that load() and loadModules() work in my own project. I don't normally use require, but I switched a couple loadModules() calls to use require(), and they worked. Maybe I'm missing something, but it seems the only thing that's necessary anymore is to wrap the esri-loader calls.